### PR TITLE
fix: pass HTTP errors through instead of crashing

### DIFF
--- a/lib/pinecone/http.ex
+++ b/lib/pinecone/http.ex
@@ -41,6 +41,8 @@ defmodule Pinecone.Http do
     {:error, body}
   end
 
+  defp parse_response({:error, _reason} = error), do: error
+
   defp url(type, endpoint, env) when type in [:indices, :collections] do
     env =
       if env do


### PR DESCRIPTION
Since this is a library, it seems prudent to let the client code handle failed requests without resorting to rescue.

<details>

<summary>Before</summary>

![Screenshot 2023-06-05 at 10 53 26 AM](https://github.com/revelrylabs/pinecone/assets/802805/7d292918-7852-4a86-b1fb-76d228c8cc26)

</details>

<details>

<summary>After</summary>

![Screenshot 2023-06-05 at 10 53 35 AM](https://github.com/revelrylabs/pinecone/assets/802805/b6d41e0e-5eee-4684-970d-9a3bb8d1f2a8)

</details>